### PR TITLE
Remove `Illuminate\Contracts\Routing\Middleware` contract

### DIFF
--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -4,9 +4,8 @@ namespace Fideloper\Proxy;
 
 use Closure;
 use Illuminate\Contracts\Config\Repository;
-use Illuminate\Contracts\Routing\Middleware;
 
-class TrustProxies implements Middleware
+class TrustProxies
 {
     /**
      * The config repository instance.


### PR DESCRIPTION
It's never been actually required for registering middleware and the interface is removed on 5.2. Removing this allow installation on Laravel 5.2