### PR TITLE
Typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ Edit `config/app.php` and add the provided Service Provider:
 ```php
 'providers' => array(
     # other providers omitted
-    Fideloper\Proxy\TrustedProxyServiceProvider,
+    Fideloper\Proxy\TrustedProxyServiceProvider::class,
 );
 ```
 


### PR DESCRIPTION
Line 142. Minor typo. Class name listed without either quotes or ::class. Added ::class.

Thanks for the handy package btw!