### PR TITLE
Update illuminate constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/contracts": "~5.0"
+        "illuminate/contracts": "5.0.* || 5.1.* || 5.2.*"
     },
     "require-dev": {
         "illuminate/http": "~5.0",


### PR DESCRIPTION
Since Laravel [doesn't follow semantic versioning](https://medium.com/@vinkla/laravel-packages-and-semantic-versioning-f62dc5accee5) we wont know if this package will break in version 5.3. The solution is to be more specific with the version constraint.