### PR TITLE
Add a double star option to address issues #46 and #49

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -9,18 +9,36 @@ return [
      * supported, along with CIDR notation.
      *
      * The "*" character is syntactic sugar
-     * within TrustedProxy to trust any proxy;
+     * within TrustedProxy to trust any proxy
+     * that connects directly to your server,
      * a requirement when you cannot know the address
      * of your proxy (e.g. if using Rackspace balancers).
+     *
+     * The "**" character is syntactic sugar within
+     * TrustedProxy to trust not just any proxy that
+     * connects directly to your server, but also
+     * proxies that connect to those proxies, and all
+     * the way back until you reach the original source
+     * IP. It will mean that $request->getClientIp()
+     * always gets the originating client IP, no matter
+     * how many proxies that client's request has
+     * subsequently passed through.
      */
     'proxies' => [
         '192.168.1.10',
     ],
 
     /*
-     * Or, to trust all proxies, uncomment this:
+     * Or, to trust all proxies that connect
+     * directly to your server, uncomment this:
      */
      # 'proxies' => '*',
+
+    /*
+     * Or, to trust ALL proxies, including those that
+     * are in a chain of fowarding, uncomment this:
+    */
+    # 'proxies' => '**',
 
     /*
      * Default Header Names

--- a/tests/TrustedProxyTest.php
+++ b/tests/TrustedProxyTest.php
@@ -42,6 +42,22 @@ class TrustedProxyTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test the next most typical usage of TrustedProxies:
+     * Trusted X-Forwarded-For header, wilcard for TrustedProxies
+     */
+    public function test_trusted_proxy_sets_trusted_proxies_with_wildcard()
+    {
+        $trustedProxy = $this->createTrustedProxy([], '*');
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(), 'Assert trusted proxy x-forwarded-for header used with wildcard proxy setting');
+        });
+    }
+
+
+
+    /**
      * Test the most typical usage of TrustProxies:
      * Trusted X-Forwarded-For header
      */
@@ -90,6 +106,54 @@ class TrustedProxyTest extends PHPUnit_Framework_TestCase
             '192.0.2.2',
             '192.0.2.2, 192.0.2.199',
             '99.99.99.99, 192.0.2.2, 192.0.2.199',
+            '192.0.2.2,192.0.2.199',
+        ];
+
+        foreach($forwardedFor as $forwardedForHeader) {
+            $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
+
+            $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
+                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+            });
+        }
+    }
+
+    /**
+     * Test X-Forwarded-For header with multiple IP addresses, with * wildcard trusting of all proxies
+     */
+    public function test_get_client_ip_with_muliple_ip_addresses_all_proxies_are_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy([], '*');
+
+        $forwardedFor = [
+            '192.0.2.2',
+            '192.0.2.199, 192.0.2.2',
+            '192.0.2.199,192.0.2.2',
+            '99.99.99.99,192.0.2.199,192.0.2.2',
+        ];
+
+        foreach($forwardedFor as $forwardedForHeader) {
+            $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_FOR' => $forwardedForHeader]);
+
+            $trustedProxy->handle($request, function ($request) use ($forwardedForHeader) {
+                $this->assertEquals('192.0.2.2', $request->getClientIp(), 'Assert sets the '.$forwardedForHeader);
+            });
+        }
+    }
+
+    /**
+     * Test X-Forwarded-For header with multiple IP addresses, with ** wildcard trusting of all proxies in the chain
+     */
+    public function test_get_client_ip_with_muliple_ip_addresses_all_proxies_and_all_forwarding_proxies_are_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy([], '**');
+
+        $forwardedFor = [
+            '192.0.2.2',
+            '192.0.2.2, 192.0.2.199',
+            '192.0.2.2, 99.99.99.99, 192.0.2.199',
+            '192.0.2.2, 2001:0db8:0a0b:12f0:0000:0000:0000:0001, 192.0.2.199',
+            '192.0.2.2, 2c01:0db8:0a0b:12f0:0000:0000:0000:0001, 192.0.2.199',
             '192.0.2.2,192.0.2.199',
         ];
 

--- a/tests/TrustedProxyTest.php
+++ b/tests/TrustedProxyTest.php
@@ -122,6 +122,8 @@ class TrustedProxyTest extends PHPUnit_Framework_TestCase
         // Create a fake request made over "http", one that we'd get over a proxy
         // which is likely something like this:
         $request = Request::create('http://localhost:8888/tag/proxy', 'GET', [], [], [], $serverOverRides, null);
+        // Need to make sure these haven't already been set
+        $request->setTrustedProxies([]);
 
         return $request;
     }


### PR DESCRIPTION
If you are in the situation where, say, you have a
Content Distribution Network (like Amazon CloudFront) that passes to load
balancer (like Amazon ELB) then you may end up with a chain of unknown
proxies forwarding from one to another. In that case, '*' above would
only match the final proxy (the load balancer in this case) which means
that calling `$request->getClientIp()` would return the IP address
of the next proxy in line (in this case one of the Content Distribution
Network ips) rather than the original client IP.To always get the original
client IP, you need to trust all the proxies in the route to your request.

You can do this by setting proxies to ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']
which means all IP addresses will be trusted.

This patch implements ** as syntactic sugar for ['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']