### PR TITLE
Added "Forwarded" header.

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -53,6 +53,7 @@ return [
      * \Symfony\Component\HttpFoundation\Request::$trustedHeaders
      */
     'headers' => [
+        \Illuminate\Http\Request::HEADER_FORWARDED    => 'FORWARDED',
         \Illuminate\Http\Request::HEADER_CLIENT_IP    => 'X_FORWARDED_FOR',
         \Illuminate\Http\Request::HEADER_CLIENT_HOST  => 'X_FORWARDED_HOST',
         \Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',


### PR DESCRIPTION
For completeness, include the "Forwarded" header in the default config (see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L74). Symfony also thoroughly documents this new standard header: http://symfony.com/doc/current/request/load_balancer_reverse_proxy.html.

Kind regards,
Jarno