### PR TITLE
Fix broken markdown syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ Edit `config/app.php` and add the provided Service Provider:
 
 This package expects the `trustedproxy.php` configuration file be available at `/config/trustedproxy.php`. You can do this by copying the package configuration file via the new Laravel 5 `artisan` command:
 
-```bash`
+```bash
 $ php artisan vendor:publish
 ```
 


### PR DESCRIPTION
It's not rendering correctly because of the backtick.