### PR TITLE
Fix spacing. Allow for on-class config

### DIFF
--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -15,6 +15,13 @@ class TrustProxies
     protected $config;
 
     /**
+     * The trusted proxies for the application.
+     *
+     * @var array
+     */
+    protected $proxies;
+
+    /**
      * Create a new trusted proxies middleware instance.
      *
      * @param  \Illuminate\Contracts\Config\Repository $config
@@ -36,7 +43,7 @@ class TrustProxies
      */
     public function handle($request, Closure $next)
     {
-		$this->setTrustedProxyHeaderNames($request);
+        $this->setTrustedProxyHeaderNames($request);
         $this->setTrustedProxyIpAddresses($request);
         return $next($request);
     }
@@ -48,43 +55,43 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddresses($request)
     {
-        $trustedIps = $this->config->get('trustedproxy.proxies');
+        $trustedIps = $this->config->get('trustedproxy.proxies', $this->proxies);
 
-		// We only trust specific IP addresses
-		if(is_array($trustedIps)) {
-			return $this->setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps);
-		} 
+        // We only trust specific IP addresses
+        if(is_array($trustedIps)) {
+            return $this->setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps);
+        }
 
-		// We trust any IP address that calls us, but not proxies further 
-		// up the forwarding chain.
+        // We trust any IP address that calls us, but not proxies further
+        // up the forwarding chain.
         if ($trustedIps === '*') {
-			return $this->setTrustedProxyIpAddressesToTheCallingIp($request);
+            return $this->setTrustedProxyIpAddressesToTheCallingIp($request);
         }
-	
-		// We trust all proxies. Those that call us, and those that are 
-		// further up the calling chain (e.g., where the X-FORWARDED-FOR
-		// header has multiple IP addresses listed);
-        if ($trustedIps === '**') {
-			return $this->setTrustedProxyIpAddressesToAllIps($request);
-        }
-	}
 
-	private function setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps)
-	{
+        // We trust all proxies. Those that call us, and those that are
+        // further up the calling chain (e.g., where the X-FORWARDED-FOR
+        // header has multiple IP addresses listed);
+        if ($trustedIps === '**') {
+            return $this->setTrustedProxyIpAddressesToAllIps($request);
+        }
+    }
+
+    private function setTrustedProxyIpAddressesToSpecificIps($request, $trustedIps)
+    {
         $request->setTrustedProxies((array) $trustedIps);
     }
 
-	private function setTrustedProxyIpAddressesToTheCallingIp($request) {
-		$request->setTrustedProxies($request->getClientIps());
-	}
+    private function setTrustedProxyIpAddressesToTheCallingIp($request) {
+        $request->setTrustedProxies($request->getClientIps());
+    }
 
-	private function setTrustedProxyIpAddressesToAllIps($request)
-	{
-		// 0.0.0.0/0 is the CIDR for all ipv4 addresses
-		// 2000:0:0:0:0:0:0:0/3 is the CIDR for all ipv6 addresses currently 
-		// allocated http://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.xhtml
-		$request->setTrustedProxies(['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
-	}
+    private function setTrustedProxyIpAddressesToAllIps($request)
+    {
+        // 0.0.0.0/0 is the CIDR for all ipv4 addresses
+        // 2000:0:0:0:0:0:0:0/3 is the CIDR for all ipv6 addresses currently
+        // allocated http://www.iana.org/assignments/ipv6-unicast-address-assignments/ipv6-unicast-address-assignments.xhtml
+        $request->setTrustedProxies(['0.0.0.0/0', '2000:0:0:0:0:0:0:0/3']);
+    }
 
     /**
      * Set the trusted header names based on teh content of trustedproxy.headers
@@ -94,7 +101,7 @@ class TrustProxies
     protected function setTrustedProxyHeaderNames($request)
     {
         $trustedHeaderNames = $this->config->get('trustedproxy.headers');
-		if(!is_array($trustedHeaderNames)) { return; } // Leave the defaults
+        if(!is_array($trustedHeaderNames)) { return; } // Leave the defaults
 
         foreach ($trustedHeaderNames as $headerKey => $headerName) {
             $request->setTrustedHeaderName($headerKey, $headerName);

--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -22,6 +22,13 @@ class TrustProxies
     protected $proxies;
 
     /**
+     * The proxy header mappings.
+     *
+     * @var array
+     */
+    protected $headers;
+
+    /**
      * Create a new trusted proxies middleware instance.
      *
      * @param  \Illuminate\Contracts\Config\Repository $config
@@ -55,7 +62,7 @@ class TrustProxies
      */
     protected function setTrustedProxyIpAddresses($request)
     {
-        $trustedIps = $this->config->get('trustedproxy.proxies', $this->proxies);
+        $trustedIps = $this->proxies ?: $this->config->get('trustedproxy.proxies');
 
         // We only trust specific IP addresses
         if(is_array($trustedIps)) {
@@ -100,7 +107,8 @@ class TrustProxies
      */
     protected function setTrustedProxyHeaderNames($request)
     {
-        $trustedHeaderNames = $this->config->get('trustedproxy.headers');
+        $trustedHeaderNames = $this->headers ?: $this->config->get('trustedproxy.headers');
+
         if(!is_array($trustedHeaderNames)) { return; } // Leave the defaults
 
         foreach ($trustedHeaderNames as $headerKey => $headerName) {


### PR DESCRIPTION
This PR fixes the mixed tab / space spacing on the middleware that was causing GitHub code display to be all wonky. Switched it to all spaces like the service provider.

In addition, I added an optional `proxies` property which just lets you specify the trusted proxies for the application directly in the middleware instead of having a separate configuration file. The same approach is taken for specifying headers using a `headers` property.

Shouldn't cause any backwards compatibility problems as configuration still falls back to the configuration file if properties are not set.

Easier to view this PR with white space diff turned off: https://github.com/fideloper/TrustedProxy/pull/63/files?w=1