### PR TITLE
Remove FORWARDED header.

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -53,7 +53,6 @@ return [
      * \Symfony\Component\HttpFoundation\Request::$trustedHeaders
      */
     'headers' => [
-        \Illuminate\Http\Request::HEADER_FORWARDED    => 'FORWARDED',
         \Illuminate\Http\Request::HEADER_CLIENT_IP    => 'X_FORWARDED_FOR',
         \Illuminate\Http\Request::HEADER_CLIENT_HOST  => 'X_FORWARDED_HOST',
         \Illuminate\Http\Request::HEADER_CLIENT_PROTO => 'X_FORWARDED_PROTO',


### PR DESCRIPTION
HEADER_FORWARDED is undefined constant in Request class... in Laravel 5.0 at least.