### PR TITLE
Allow distrusting headers in the documented form (setting the header to null)

### DIFF
--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -158,12 +158,21 @@ class TrustProxies
      */
     protected function getTrustedHeaderSet()
     {
-        return array_reduce(array_keys($this->getTrustedHeaderNames()), function ($set, $key) {
+        $trustedHeaderNames = $this->getTrustedHeaderNames();
+        $headerKeys = array_keys($this->getTrustedHeaderNames());
+
+        return array_reduce($headerKeys, function ($set, $key) use ($trustedHeaderNames) {
             // PHP 7+ gives a warning if non-numeric value is used
             // resulting in a thrown ErrorException within Laravel
             // This error occurs with Symfony < 3.3, PHP7+
-            if(! is_numeric($set) || ! is_numeric($key)) {
-                return;
+            if(! is_numeric($key)) {
+                return $set;
+            }
+
+            // If the header value is null, it is a distrusted header,
+            // so we will ignore it and move on.
+            if (is_null($trustedHeaderNames[$key])) {
+                return $set;
             }
 
             return $set | $key;


### PR DESCRIPTION
see #70, previous fix for Symfony 3.3 changes meant that this did not function as expected.