### PR TITLE
Merge config file in the service registration

### DIFF
--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -9,11 +9,11 @@ use Laravel\Lumen\Application as LumenApplication;
 class TrustedProxyServiceProvider extends ServiceProvider
 {
     /**
-     * Boot the service provider.
+     * Register the service provider.
      *
      * @return void
      */
-    public function boot()
+    public function register()
     {
         $source = realpath(__DIR__.'/../config/trustedproxy.php');
 
@@ -24,15 +24,5 @@ class TrustedProxyServiceProvider extends ServiceProvider
         }
 
         $this->mergeConfigFrom($source, 'trustedproxy');
-    }
-
-    /**
-     * Register the service provider.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        //
     }
 }


### PR DESCRIPTION
In this PR, I simply renamed the `boot` to `register`, and deleted `boot` as it is unused for now.

`mergeConfigFrom` should be called in the `register` method, it means once the package being registered, its config are ready to use. Then other services can access them safely without caring about the order of application services bootstrap.

This is also mentioned in the [official documentation](https://laravel.com/docs/5.5/packages#configuration):
> To merge the configurations, use the mergeConfigFrom method within your service provider's register method.

`publishes` is useful only in the console application, and in the console application all services will be booted, so it does not matter putting `publishes` whether in `register` or `boot` method. Some core services also put it in `register` to make code organized, such as `MailServiceProvider::registerMarkdownRenderer`.