### PR TITLE
 fix "failed to open required file" for config file

### DIFF
--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -18,7 +18,7 @@ class TrustedProxyServiceProvider extends ServiceProvider
         $source = __DIR__.'/../config/trustedproxy.php';
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
-            $this->publishes([realpath($source) => config_path('trustedproxy.php')]);
+            $this->publishes([$source => config_path('trustedproxy.php')]);
         } elseif ($this->app instanceof LumenApplication) {
             $this->app->configure('trustedproxy');
         }

--- a/src/TrustedProxyServiceProvider.php
+++ b/src/TrustedProxyServiceProvider.php
@@ -15,10 +15,10 @@ class TrustedProxyServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $source = realpath(__DIR__.'/../config/trustedproxy.php');
+        $source = __DIR__.'/../config/trustedproxy.php';
 
         if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
-            $this->publishes([$source => config_path('trustedproxy.php')]);
+            $this->publishes([realpath($source) => config_path('trustedproxy.php')]);
         } elseif ($this->app instanceof LumenApplication) {
             $this->app->configure('trustedproxy');
         }


### PR DESCRIPTION
This will fix "failed to open required file" When we use this package (with laravel) inside phar archive.

The problem happen because realpath will return the full path when the package no longer exist in disk.

With this pull request the path will be relative and will work inside phar archive.