### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/TrustedProxyTest.php
+++ b/tests/TrustedProxyTest.php
@@ -2,8 +2,9 @@
 
 use Fideloper\Proxy\TrustProxies;
 use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
 
-class TrustedProxyTest extends PHPUnit_Framework_TestCase
+class TrustedProxyTest extends TestCase
 {
     /**
      * Test that Symfony does indeed NOT trust X-Forwarded-*


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).