### PR TITLE
adding support for AWS ELB. Accept IPs separated by comma.

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -22,7 +22,7 @@ return [
      * directly to your server, use an array or a string separated by comma of IP addresses:
      */
     // 'proxies' => ['192.168.1.1'],
-    // 'proxies' => '192.168.1.1, 192.168.1.1',
+    // 'proxies' => '192.168.1.1, 192.168.1.2',
 
     /*
      * Or, to trust all proxies that connect

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -15,7 +15,7 @@ return [
      * of your proxy (e.g. if using ELB or similar).
      *
      */
-    'proxies' => null, // [<ip addresses>,], '*'
+    'proxies' => null, // [<ip addresses>,], '*', '<ip addresses>,'
 
     /*
      * To trust one or more specific proxies that connect
@@ -36,10 +36,14 @@ return [
      * 
      * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
      * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
+     * - Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB (If you are using AWS Elastic Load Balancer)
+     *
+     * - 'HEADER_X_FORWARDED_ALL' (use all x-forwarded-* headers to establish trust)
+     * - 'HEADER_FORWARDED' (use the FORWARDED header to establish trust)
+     * - 'HEADER_X_FORWARDED_AWS_ELB' (If you are using AWS Elastic Load Balancer)
      * 
      * @link https://symfony.com/doc/current/deployment/proxies.html
      */
     'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL,
 
-    
 ];

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -19,15 +19,16 @@ return [
 
     /*
      * To trust one or more specific proxies that connect
-     * directly to your server, use an array of IP addresses:
+     * directly to your server, use an array or a string separated by comma of IP addresses:
      */
-     # 'proxies' => ['192.168.1.1'],
+    // 'proxies' => ['192.168.1.1'],
+    // 'proxies' => '192.168.1.1, 192.168.1.1',
 
     /*
      * Or, to trust all proxies that connect
      * directly to your server, use a "*"
      */
-     # 'proxies' => '*',
+    // 'proxies' => '*',
 
     /*
      * Which headers to use to detect proxy related data (For, Host, Proto, Port)

--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -113,16 +113,16 @@ class TrustProxies
         switch ($headers) {
             case 'HEADER_X_FORWARDED_AWS_ELB':
             case Request::HEADER_X_FORWARDED_AWS_ELB:
-                $headers = Request::HEADER_X_FORWARDED_AWS_ELB;
+                $this->headers = Request::HEADER_X_FORWARDED_AWS_ELB;
                 break;
             case 'HEADER_FORWARDED':
             case Request::HEADER_FORWARDED:
-                $headers = Request::HEADER_FORWARDED;
+                $this->headers = Request::HEADER_FORWARDED;
                 break;
             default:
-                $headers = Request::HEADER_X_FORWARDED_ALL;
+                $this->headers = Request::HEADER_X_FORWARDED_ALL;
         }
 
-        $this->headers = $headers;
+        return $this->headers;
     }
 }

--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -73,7 +73,7 @@ class TrustProxies
         }
 
         // Support IPs addresses separated by comma
-        $trustedIps = is_string($trustedIps) ? explode(',', $trustedIps) : $trustedIps;
+        $trustedIps = is_string($trustedIps) ? array_map('trim', explode(',', $trustedIps)) : $trustedIps;
 
         // Only trust specific IP addresses
         if (is_array($trustedIps)) {
@@ -105,7 +105,7 @@ class TrustProxies
     /**
      * Retrieve trusted header name(s), falling back to defaults if config not set.
      *
-     * @return array
+     * @return int A bit field of Request::HEADER_*, to set which headers to trust from your proxies.
      */
     protected function getTrustedHeaderNames()
     {


### PR DESCRIPTION
1. Accept IPs separated by comma.
    - Probably In a project like Laravel you need to add this config to the .env file and array is not supported in .env
```config
TRUSTEDPROXY_PROXIES='192.168.1.1, 192.168.1.2'
```
```php
'proxies' => env('TRUSTEDPROXY_PROXIES', null),
```

2. Accept headers as a string.
    - Probably In a project like Laravel you need to add this config to the .env file and you can pass the header you want to use as a string:
```config
TRUSTEDPROXY_HEADERS='HEADER_X_FORWARDED_AWS_ELB'
```
```php
'headers' => env('TRUSTEDPROXY_HEADERS', 'HEADER_X_FORWARDED_ALL'),
```

