### PR TITLE
Fixes for no_trailing_whitespace_in_comment

### DIFF
--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -32,9 +32,9 @@ return [
 
     /*
      * Which headers to use to detect proxy related data (For, Host, Proto, Port)
-     * 
+     *
      * Options include:
-     * 
+     *
      * - Illuminate\Http\Request::HEADER_X_FORWARDED_ALL (use all x-forwarded-* headers to establish trust)
      * - Illuminate\Http\Request::HEADER_FORWARDED (use the FORWARDED header to establish trust)
      * - Illuminate\Http\Request::HEADER_X_FORWARDED_AWS_ELB (If you are using AWS Elastic Load Balancer)
@@ -42,7 +42,7 @@ return [
      * - 'HEADER_X_FORWARDED_ALL' (use all x-forwarded-* headers to establish trust)
      * - 'HEADER_FORWARDED' (use the FORWARDED header to establish trust)
      * - 'HEADER_X_FORWARDED_AWS_ELB' (If you are using AWS Elastic Load Balancer)
-     * 
+     *
      * @link https://symfony.com/doc/current/deployment/proxies.html
      */
     'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL,


### PR DESCRIPTION
I am absolutely being completely nit picky, but I am also trying to cut down on the number of files in my second commit in every project which is after running `php-cs-fixer`. As there is mixed usage in this file, I thought I would take the opportunity, as I am operating under the belief that the framework already checks for this.