### PR TITLE
Allow Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/contracts": "~5.0|~6.0"
+        "illuminate/contracts": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "illuminate/http": "~5.6|~6.0",
-        "mockery/mockery": "~1.0",
+        "illuminate/http": "^5.0|^6.0|^7.0",
+        "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
The `develop` branch of laravel/laravel is soon to be Laravel 7. In order to do this, we'd need this package to allow the framework version 7.

<img width="268" alt="image" src="https://user-images.githubusercontent.com/2829600/64188629-ae70e400-ce6a-11e9-98f6-9ffea1e5855b.png">
