### PR TITLE
Support custom trusted header bitmasks

### DIFF
--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -110,20 +110,20 @@ class TrustProxies
     protected function getTrustedHeaderNames()
     {
         $headers = $this->headers ?: $this->config->get('trustedproxy.headers');
+
+        if (is_int($headers)) {
+            return $headers;
+        }
+
         switch ($headers) {
             case 'HEADER_X_FORWARDED_AWS_ELB':
-            case Request::HEADER_X_FORWARDED_AWS_ELB:
                 return Request::HEADER_X_FORWARDED_AWS_ELB;
                 break;
             case 'HEADER_FORWARDED':
-            case Request::HEADER_FORWARDED:
                 return Request::HEADER_FORWARDED;
                 break;
             default:
                 return Request::HEADER_X_FORWARDED_ALL;
         }
-
-        // Should never reach this point
-        return $headers;
     }
 }

--- a/tests/TrustedProxyTest.php
+++ b/tests/TrustedProxyTest.php
@@ -218,6 +218,22 @@ class TrustedProxyTest extends TestCase
         });
     }
 
+    public function test_can_use_custom_header_bitmasks()
+    {
+        $request = $this->createProxiedRequest();
+
+        // trust *all* "X-Forwarded-*" headers except X-Forwarded-Port
+        $trustedProxy = $this->createTrustedProxy(
+            Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_PORT,
+            '192.168.1.1, 192.168.1.2');
+        $trustedProxy->handle($request, function (Request $request) {
+            $this->assertEquals(
+                $request->getTrustedHeaderSet(),
+                Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_PORT,
+                'Assert trusted proxy used custom "X-Forwarded-*" headers');
+        });
+    }
+
     ################################################################
     # Utility Functions
     ################################################################


### PR DESCRIPTION
This PR adds support for custom bitmasks, which are necessary if your load balancer doesn't support all `X-Forwarded-*` headers and doesn't support the same subset of `X-Forwarded-*` headers that AWS ELB uses. I personally ran into this while using ngrok via `valet share`, which doesn't send `HEADER_X_FORWARDED_PORT`.