### PR TITLE
Allow Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/contracts": "^5.0|^6.0|^7.0"
+        "illuminate/contracts": "^5.0|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "illuminate/http": "^5.0|^6.0|^7.0",
+        "illuminate/http": "^5.0|^6.0|^7.0|^8.0",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.0"
     },


### PR DESCRIPTION
`laravel/laravel`'s develop branch will become Laravel 8 in the first week of March. This PR will allow us to keep this package in there.