### PR TITLE
Security fix for proxying individual X-Forwarded-* headers.

### DIFF
--- a/src/TrustProxies.php
+++ b/src/TrustProxies.php
@@ -119,11 +119,12 @@ class TrustProxies
             case Request::HEADER_FORWARDED:
                 return Request::HEADER_FORWARDED;
                 break;
-            default:
+            case 'HEADER_X_FORWARDED_ALL':
+            case Request::HEADER_X_FORWARDED_ALL:
                 return Request::HEADER_X_FORWARDED_ALL;
+                break;
         }
 
-        // Should never reach this point
         return $headers;
     }
 }

--- a/tests/TrustedProxyTest.php
+++ b/tests/TrustedProxyTest.php
@@ -181,6 +181,110 @@ class TrustedProxyTest extends TestCase
     }
 
     /**
+     * Test that only the X-Forwarded-For header is trusted.
+     */
+    public function test_x_forwarded_for_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_FOR, '*');
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+                'Assert trusted proxy used forwarded header for IP');
+            $this->assertEquals('http', $request->getScheme(),
+                'Assert trusted proxy did not use forwarded header for scheme');
+            $this->assertEquals('localhost', $request->getHost(),
+                'Assert trusted proxy did not use forwarded header for host');
+            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-Host header is trusted.
+     */
+    public function test_x_forwarded_host_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_HOST, '*');
+
+        $request = $this->createProxiedRequest(['HTTP_X_FORWARDED_HOST' => 'serversforhackers.com:8888']);
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('http', $request->getScheme(),
+                'Assert trusted proxy did not use forwarded header for scheme');
+            $this->assertEquals('serversforhackers.com', $request->getHost(),
+                'Assert trusted proxy used forwarded header for host');
+            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-Port header is trusted.
+     */
+    public function test_x_forwarded_port_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_PORT, '*');
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('http', $request->getScheme(),
+                'Assert trusted proxy did not use forwarded header for scheme');
+            $this->assertEquals('localhost', $request->getHost(),
+                'Assert trusted proxy did not use forwarded header for host');
+            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+        });
+    }
+
+    /**
+     * Test that only the X-Forwarded-Proto header is trusted.
+     */
+    public function test_x_forwarded_proto_header_only_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(Request::HEADER_X_FORWARDED_PROTO, '*');
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('192.168.10.10', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('https', $request->getScheme(),
+                'Assert trusted proxy used forwarded header for scheme');
+            $this->assertEquals('localhost', $request->getHost(),
+                'Assert trusted proxy did not use forwarded header for host');
+            $this->assertEquals(8888, $request->getPort(), 'Assert trusted proxy did not use forwarded header for port');
+        });
+    }
+
+    /**
+     * Test a combination of individual X-Forwarded-* headers are trusted.
+     */
+    public function test_x_forwarded_multiple_individual_headers_trusted()
+    {
+        $trustedProxy = $this->createTrustedProxy(
+            Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_HOST |
+            Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO,
+            '*'
+        );
+
+        $request = $this->createProxiedRequest();
+
+        $trustedProxy->handle($request, function ($request) {
+            $this->assertEquals('173.174.200.38', $request->getClientIp(),
+                'Assert trusted proxy did not use forwarded header for IP');
+            $this->assertEquals('https', $request->getScheme(),
+                'Assert trusted proxy used forwarded header for scheme');
+            $this->assertEquals('serversforhackers.com', $request->getHost(),
+                'Assert trusted proxy used forwarded header for host');
+            $this->assertEquals(443, $request->getPort(), 'Assert trusted proxy used forwarded header for port');
+        });
+    }
+
+    /**
      * Test to ensure it's reading text-based configurations and converting it correctly.
      */
     public function test_is_reading_text_based_configurations()

--- a/tests/TrustedProxyTest.php
+++ b/tests/TrustedProxyTest.php
@@ -275,7 +275,7 @@ class TrustedProxyTest extends TestCase
 
         $trustedProxy->handle($request, function ($request) {
             $this->assertEquals('173.174.200.38', $request->getClientIp(),
-                'Assert trusted proxy did not use forwarded header for IP');
+                'Assert trusted proxy used forwarded header for IP');
             $this->assertEquals('https', $request->getScheme(),
                 'Assert trusted proxy used forwarded header for scheme');
             $this->assertEquals('serversforhackers.com', $request->getHost(),


### PR DESCRIPTION
There's a security issue wherein proxying a single (or set of) header/s (eg. `X-Forwarded-For`) will result in proxying all of the `X-Forwarded-*` headers. This is incredibly bad practice and opens room for various malicious attacks.

For example, if someone were to trust all proxies (which, whilst commonly bad practice, does in fact commonly occur in an environment where you may be using a load balancer. For example, restricting origin access to a load balancer and the load balancer to a reverse proxy provider) then Laravel will begin generating URLs with the user-supplied `X-Forwarded-Host` header.

When you combine this with an email, you're able to trick the system into sending an email using a URL that does not belong to the service. This attack is amplified as Laravel's default password reset system generates URLs that adhere to the host supplied in `X-Fowarded-Host` which ultimately can result in a password reset token leak.

Further, in general, if people are customising which headers are proxied, they expect it to only proxy those headers and not everything.

I've added tests for all of the individual scenarios as well as a scenario where the headers are combined individually.