### PR TITLE
Removed odd phpunit option

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Trusted Proxy Test Suite">


### PR DESCRIPTION
This odd option generates warning "Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed. Test results may not be as expected."

You could see it, for example, here:
https://github.com/fideloper/TrustedProxy/runs/1517618439?check_suite_focus=true

![image](https://user-images.githubusercontent.com/8986207/103174684-dc9ee200-486c-11eb-9361-5a604c364dee.png)

See more:
https://stackoverflow.com/questions/44328114/phpunit-what-does-syntaxcheck-configuration-parameter-stands-for-exactly